### PR TITLE
add a minlength to the name form

### DIFF
--- a/server/views/index.pug
+++ b/server/views/index.pug
@@ -37,7 +37,7 @@ block content
               input#joinincode.form-control(type='text', placeholder='abcd', autocomplete='off')
             label Name:
             .form-group
-              input#joininname.form-control(type='text', placeholder='Use your real name!', maxlength=16)
+              input#joininname.form-control(type='text', placeholder='Use your real name!', minlength=3, maxlength=16)
           .btn-toolbar
             button#joinmenu-back.btn.btn-default.btn-lg.mr-2(type='button') Back
             button#joinmenu-go.btn.btn-default.btn-lg(type='submit') Join
@@ -47,7 +47,7 @@ block content
           .input-container
             label Name:
             .form-group
-              input#newinname.form-control(type='text', placeholder='Use your real name!', maxlength=16)
+              input#newinname.form-control(type='text', placeholder='Use your real name!', minlength=3, maxlength=16)
           .btn-toolbar 
             button#newmenu-back.btn.btn-default.btn-lg.mr-2(type='button') Back
             button#newmenu-go.btn.btn-default.btn-lg(type='submit') Start


### PR DESCRIPTION
Hi there, 
I'm a new player and chose "D" as my name. When I got the "Name too short/long" error message, I couldn't figure out how to change my name. I  thought maybe the game was buggy and I couldn't edit it! I had to load the game in a browser on my computer to realize that the pencil was clickable. To me, it's non-obvious on mobile.

I thought of a few different ways to fix that problem:
- swap the "You, Host" text with the pencil icon. If it came after, I think it would be more obvious that it's a button. We're used to seeing a picture to the left of a person's name, or other text, just as decoration.
- add an extra sentence to the error message that says something like "tap the pencil icon to edit" or, if it needs to be as short as the "Name too short/long" line, it could say "Tap pencil to edit". But I'm not sure if your button design has room for a second row of text.
-make the pencil smaller and say "edit" underneath
- instead of the pencil icon, just use the word edit as a clickable link (maybe with a box, maybe without)

Then I realized that both the easiest and most useful way to handle this is to not let the user submit an invalid name in the first place. If you don't like the way that HTML's buit-in minlength handles this, you could write some custom JS to check on button-click if it's > 2

Note: Apologies, but I didn't set up a whole dev environment just to test this small change, so you'll have to do the verification if you want to merge this in.